### PR TITLE
Added hook to modify the generated GraphQL schema

### DIFF
--- a/ProcessGraphQL.module
+++ b/ProcessGraphQL.module
@@ -34,6 +34,19 @@ class ProcessGraphQL extends Process implements Module {
 		$this->addHookAfter('Template::changed', $this, 'hookTemplateNameChange');
 	}
 
+	/**
+   * The hook for modifying the GraphQL schema types by the user.
+   * The schema is an array of types that will be set to GraphQL types.
+   * Custom types could be added bu just appending them into an array.
+   * See the documentation of the library used by this module to learn more
+   * @see  The GraphQL lib https://github.com/webonyx/graphql-php
+   * @param  $schema    
+   * @return $schema
+   */
+	public function ___modifySchema($schema) {
+		return $schema;
+	}
+
   /**
    * Updates the legalTemplates on name change. Template names for ProcessWire
    * are not necessarily valid for GraphQL field naming. Those names that are

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -45,6 +45,9 @@ class Schema
       $schema['mutation'] = $mutation;
     }
 
+    // Let the user or other modules modify the schema.
+    $schema = Utils::module()->modifySchema($schema);
+
     self::$schema = new GraphQLSchema($schema);
   }
 


### PR DESCRIPTION
Since I am developing an extension for ProcessGraphQL, which should enable subscriptions for the Processwire GraphQL endpoint, I need a way to modify the GraphQL schema generated by ProcessGraphQL. 

With this pull request, the schema can be modified by other packages to add some more types. This could also be useful for other packages, to add more functionality to the GraphQL Endpoint.