### PR TITLE
Fixed DateTime parsing

### DIFF
--- a/src/Type/Fieldtype/FieldtypeDatetime.php
+++ b/src/Type/Fieldtype/FieldtypeDatetime.php
@@ -1,5 +1,6 @@
 <?php namespace ProcessWire\GraphQL\Type\Fieldtype;
 
+use DateTime;
 use ProcessWire\Page;
 use GraphQL\Type\Definition\Type;
 use GraphQL\Type\Definition\CustomScalarType;
@@ -24,7 +25,7 @@ class FieldtypeDatetime
           return (string) $value;
         },
         'parseValue' => function ($value) {
-          return (string) $value;
+          return new DateTime($value);
         },
         'parseLiteral' => function ($valueNode) {
           return (string) $valueNode->value;


### PR DESCRIPTION
When creating or updating a page with a field of type DateTime, it produces the error `Call to a member function format() on string`. This pull request provides a fix for this bug by parsing the given string into the expected DateTime.